### PR TITLE
freebsd-src-regression-suite: add "" around the test list

### DIFF
--- a/bricoler
+++ b/bricoler
@@ -2888,7 +2888,7 @@ the VM is shut down.
                 "-j", self.parallelism or self.ncpus,
                 "-o", reportpath,
                 "-r", dbpath,
-                self.tests,
+                "\"" .. self.tests .. "\"",
             }
             local testcmd = sprintf("/root/run-kyua %s", table.concat(testparams, " "))
             self.VM:consrun(testcmd, 12 * 60 * 60)


### PR DESCRIPTION
This allows us to specify multiple tests
(e.g. -p "freebsd-src-regression-suite:tests=sys/netpfil sbin/pfctl"), which is useful if we want to run multiple test suites on the same image.

Sponsored by:	Rubicon Communications, LLC ("Netgate")