### PR TITLE
freebsd-src-build: default to WITH_CCACHE

### DIFF
--- a/bricoler
+++ b/bricoler
@@ -1825,6 +1825,10 @@ Task{
             description = "Clean the build directory before building",
             default = false,
         },
+        ccache = {
+            description = "Enable ccache support to speed up the build",
+            default = true,
+        },
         kernel_config = {
             description = "The kernel configuration file to use for buildkernel",
             type = "string",
@@ -1923,6 +1927,7 @@ Task{
                     "METALOG=" .. metalog,
                     "TARGET=" .. machine,
                     self.clean and "WITH_CLEAN=" or "WITHOUT_CLEAN=",
+                    self.ccache and "WITH_CCACHE=" or "WITHOUT_CCACHE=",
                 }
                 table.insert(args, machine_arch and "TARGET_ARCH=" .. machine_arch or nil)
                 table.insert(args, self.kernel_config and "KERNCONF=" .. self.kernel_config or nil)


### PR DESCRIPTION
CCACHE builds significantly speed up my workflows where I make a tiny change to the src/ tree and need to rerun a test. Ccache already has very good logic to determine whether to rebuild something or not (with a user-provided `ccache.conf` in a user's own ccache directory to tune that logic). Keeping it on by default would enable very rapid prototyping cycles for developers. And anyone who doesn't want that can use the `freebsd-src-build:ccache=false` knob.