### PR TITLE
VMRun: allow running riscv64 guests with RVVM

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -23,7 +23,7 @@ from .git import GitRepository
 from .mtree import MtreeFile
 from .task import Task, TaskParameter, TaskMeta, TaskSchedule
 from .util import chdir, host_machine, info, run_cmd, warn
-from .vm import FreeBSDVM, VMImage, VMHypervisor, BhyveRun, QEMURun, SSHCommandRunner
+from .vm import FreeBSDVM, VMImage, VMHypervisor, BhyveRun, QEMURun, RVVMRun, SSHCommandRunner
 
 
 class FreeBSDSrcRepository(GitRepository):
@@ -658,7 +658,10 @@ class FreeBSDVMBootTask(Task):
     }
 
     def run(self, ctx):
-        cls = QEMURun if self.hypervisor == VMHypervisor.QEMU else BhyveRun
+        match self.hypervisor:
+            case VMHypervisor.BHYVE: cls = BhyveRun
+            case VMHypervisor.QEMU: cls = QEMURun
+            case VMHypervisor.RVVM: cls = RVVMRun
         if self.p9_shares:
             p9_shares = [tuple(desc.split(':')) for desc in self.p9_shares.split(',')]
         else:

--- a/src/bricoler/vm.py
+++ b/src/bricoler/vm.py
@@ -76,6 +76,7 @@ class VMRun:
     class NetworkDriver(Enum):
         VIRTIO = 1,
         E1000 = 2,
+        NONE = 3,
 
     def __init__(
         self,
@@ -163,11 +164,10 @@ class BhyveRun(VMRun):
         })
 
     def network_driver_name(self) -> str:
-        driver = self.nic_driver
-        if driver == VMRun.NetworkDriver.VIRTIO:
-            return "virtio-net"
-        elif driver == VMRun.NetworkDriver.E1000:
-            return "e1000"
+        match self.nic_driver:
+            case VMRun.NetworkDriver.VIRTIO: return "virtio-net"
+            case VMRun.NetworkDriver.E1000: return "e1000"
+        raise ValueError(f"Unsupported network driver {driver} is not supported by bhyve")
 
     def setup(self) -> List[Any]:
         if BhyveRun.has_monitor_mode():
@@ -210,7 +210,8 @@ class BhyveRun(VMRun):
         add_device(f"{self.block_driver_name()},{self.image.path}")
         for disk in self.extra_disks:
             add_device(f"{self.block_driver_name()},{disk}")
-        add_device(f"{self.network_driver_name()},slirp,open,hostfwd=tcp:{self.ssh_addr[0]}:{self.ssh_addr[1]}-:22")
+        if self.nic_driver != VMRun.NetworkDriver.NONE:
+            add_device(f"{self.network_driver_name()},slirp,open,hostfwd=tcp:{self.ssh_addr[0]}:{self.ssh_addr[1]}-:22")
         for share in self.p9_shares:
             add_device(f"virtio-9p,{share[0]}={share[1]}")
 
@@ -290,8 +291,6 @@ class QEMURun(VMRun):
             "-device", "virtio-rng-pci",
             "-device", f"{self.block_driver_name()},drive=image",
             "-drive", f"file={self.image.path},if=none,id=image,format=raw",
-            "-device", f"{self.nic_driver_name()},netdev=net0",
-            "-netdev", f"user,id=net0,hostfwd=tcp:{self.ssh_addr[0]}:{self.ssh_addr[1]}-:22",
             "-gdb", f"tcp:{self.gdb_addr[0]}:{self.gdb_addr[1]}",
         ]
         for disk in self.extra_disks:
@@ -312,6 +311,11 @@ class QEMURun(VMRun):
         kernel_path = self.kernel_path()
         if kernel_path is not None:
             qemu_cmd.extend(["-kernel", kernel_path])
+        if self.nic_driver != VMRun.NetworkDriver.NONE:
+            qemu_cmd.extend([
+                "-device", f"{self.nic_driver_name()},netdev=net0",
+                "-netdev", f"user,id=net0,hostfwd=tcp:{self.ssh_addr[0]}:{self.ssh_addr[1]}-:22",
+            ])
 
         return [str(a) for a in qemu_cmd]
 

--- a/src/bricoler/vm.py
+++ b/src/bricoler/vm.py
@@ -65,6 +65,7 @@ class VMImage:
 class VMHypervisor(Enum):
     BHYVE = 'bhyve'
     QEMU = 'qemu'
+    RVVM = 'rvvm'
 
 
 class VMRun:
@@ -219,6 +220,27 @@ class BhyveRun(VMRun):
 
         return [str(a) for a in bhyve_cmd]
 
+
+class RVVMRun(VMRun):
+    def setup(self) -> List[str]:
+        rvvm_cmd = [
+            "rvvm",
+            "/usr/local/share/RVVM/fw_payload.bin",
+            "-image", f"{self.image.path}",
+            "-mem", f"{self.memory}M",
+            "-smp", f"{self.ncpus}",
+            "-nogui",
+        ]
+
+        match self.nic_driver:
+            case VMRun.NetworkDriver.VIRTIO:
+                rvvm_cmd.extend(["-portfwd", f"tcp/{self.ssh_addr[0]}:{self.ssh_addr[1]}=22"])
+            case VMRun.NetworkDriver.NONE:
+                rvvm_cmd.extend(["-nonet"])
+            case _:
+                raise ValueError(f"Unsupported network driver {self.nic_driver} is not supported by RVVM")
+
+        return rvvm_cmd
 
 class QEMURun(VMRun):
     def bios_path(self) -> Optional[Path]:


### PR DESCRIPTION
See individual commits.

NOTE: RVVM support requires upstream RVVM, not the current `emulators/rvvm` freebsd port. Currently pending the addition of `emulators/rvvm-devel` tracking upstream HEAD.