### PR TITLE
freebsd-regression-test-suite: use comma-separated list for tests

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -849,7 +849,7 @@ class FreeBSDRegressionTestSuiteTask(FreeBSDVMBootTask):
             default=os.cpu_count() // 2,  # XXX-MJ duplicating the ncpus value
         ),
         'tests': TaskParameter(
-            description="A space-separated list of test cases or test suites to run, "
+            description="A comma-separated list of test cases or test suites to run, "
                         "or the empty string to run all tests",
             default="",
         ),
@@ -871,7 +871,7 @@ class FreeBSDRegressionTestSuiteTask(FreeBSDVMBootTask):
                 "-j", str(self.parallelism),
                 "-r", "/root/kyua.db",
                 "-o", "/root/kyua-report.txt",
-                self.tests
+                self.tests.replace(',', ' ')
             ]
             vm.sendline(" ".join(cmd))
             vm.wait_for_prompt(timeout=10*3600)


### PR DESCRIPTION
This makes it so much easier to write tooling on top of bricoler, due to very complicated shell space quoting rules.