### PR TITLE
vm-src-build: set WITH_CCACHE_BUILD=yes

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -228,6 +228,7 @@ class FreeBSDSrcBuildTask(Task):
                 "MAKEOBJDIRPREFIX": objdir,
                 "SRCCONF": "/dev/null",
                 "__MAKE_CONF": "/dev/null",
+                "WITH_CCACHE_BUILD": "yes",
             }
 
             self.src.repo.make(args, env=env)


### PR DESCRIPTION
This improves incremental compilation speed, especially when bisecting a src tree. Large changes to header files across the tree cause large incremental rebuilds even with META_MODE, but they are trivially cached by CCACHE if the dependencies don't change.