### PR TITLE
Reliably disable mac modules on load

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -765,6 +765,10 @@ class FreeBSDRegressionTestSuiteVMImageTask(FreeBSDVMImageTask):
         "net.inet.ip.fw.default_to_accept=1",
         "net.inet.ipf.jail_allowed=1",
         "net.fibs=8",
+        "security.mac.bsdextended.enabled=0",
+        "security.mac.ipacl.ipv4=0",
+        "security.mac.ipacl.ipv6=0",
+        "security.mac.portacl.enabled=0",
     ])
 
     packages = " ".join([
@@ -827,10 +831,6 @@ class FreeBSDRegressionTestSuiteVMImageTask(FreeBSDVMImageTask):
         "vfs.aio.enable_unsafe=1",
         "kern.crypto.allow_soft=1",
         "vm.panic_on_oom=1",
-        "security.mac.bsdextended.enabled=0",
-        "security.mac.ipacl.ipv4=0",
-        "security.mac.ipacl.ipv6=0",
-        "security.mac.portacl.enabled=0",
     ])
 
     inputs = {


### PR DESCRIPTION
Follow suit of https://github.com/freebsd/freebsd-ci/commit/9003c8decc7ba8a879464d26cd9ea724128e6695 to fix stable/14 test unreliability (as seen in https://ci.freebsd.org/job/FreeBSD-stable-14-amd64-test/1897/)