### PR TITLE
freebsd-src-build: output errors in make(1) commands

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -261,6 +261,7 @@ class FreeBSDSrcBuildTask(Task):
             args = [
                 target,
                 "-ss",
+                "-de",
                 "-j", ctx.max_jobs,
                 "-DNO_ROOT",
                 f"DESTDIR={stagedir}",
@@ -286,6 +287,7 @@ class FreeBSDSrcBuildTask(Task):
                 "MAKEOBJDIRPREFIX": objdir,
                 "SRCCONF": "/dev/null",
                 "__MAKE_CONF": "/dev/null",
+                "SRC_ENV_CONF": "/dev/null",
             }
 
             self.src.repo.make(args, env=env)


### PR DESCRIPTION
This helps prioritize any error codes at the top of the log and reveals what we need to clean up in the build system.

While here, add a missing SRC_ENV_CONF=/dev/null to the environment.