### PR TITLE
tcp_unused_addr: use localhost instead of hardcoding 127.0.0.1

### DIFF
--- a/src/bricoler/util.py
+++ b/src/bricoler/util.py
@@ -143,6 +143,5 @@ def warn(message: str):
 
 
 def unused_tcp_addr() -> Tuple[str, int]:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('127.0.0.1', 0))
+    with socket.create_server(('localhost', 0), family=socket.AF_INET) as s:
         return s.getsockname()


### PR DESCRIPTION
while here, simplify the command with an available convenience wrapper