### PR TITLE
config: actually create a Path object from opts.workdir

### DIFF
--- a/src/bricoler/config.py
+++ b/src/bricoler/config.py
@@ -117,7 +117,7 @@ class Config:
         self.max_jobs = opts.max_jobs
         self.skip = opts.skip
         self.wait = opts.wait
-        self.workdir = opts.workdir
+        self.workdir = Path(opts.workdir).resolve()
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.config_path = Path(self.workdir / 'bricoler.json')
 


### PR DESCRIPTION
Missed this in testing.

Fixes:	e80bc07cb64496222dba6d532fb4ebf5d45511fb