### PR TITLE
Parse and validate the p9_shares parameter early

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -23,7 +23,7 @@ from .config import Config
 from .git import GitRepository
 from .mtree import MtreeFile
 from .task import Task, TaskParameter, TaskParameterBinding, TaskMeta, TaskSchedule
-from .util import EmailReport, chdir, host_machine, info, run_cmd, warn
+from .util import EmailReport, chdir, host_machine, info, parse_p9, run_cmd, warn
 from .vm import FreeBSDVM, VMImage, VMHypervisor, BhyveRun, QEMURun, RVVMRun, SSHCommandRunner, VMRun
 
 
@@ -762,7 +762,8 @@ class FreeBSDVMBootTask(Task):
         ),
         'p9_shares': TaskParameter(
             description="Comma-separated list of shares of the form <share>:<path>",
-            type=str,  # XXX-MJ List[Tuple[str, Path]]
+            default=[],
+            type=parse_p9
         ),
         'reboot': TaskParameter(
             description="Restart the VM when it exits due to a reboot",
@@ -779,10 +780,6 @@ class FreeBSDVMBootTask(Task):
             case VMHypervisor.BHYVE: cls = BhyveRun
             case VMHypervisor.QEMU: cls = QEMURun
             case VMHypervisor.RVVM: cls = RVVMRun
-        if self.p9_shares:
-            p9_shares = [tuple(desc.split(':')) for desc in self.p9_shares.split(',')]
-        else:
-            p9_shares = []
         vmrun = cls(
             image=self.vm_image.image,
             extra_disks=self.disk_list.split() if self.disk_list else [],
@@ -790,7 +787,7 @@ class FreeBSDVMBootTask(Task):
             ncpus=self.ncpus,
             block_driver=self.block_driver,
             nic_driver=self.nic_driver,
-            p9_shares=p9_shares,
+            p9_shares=self.p9_shares,
             ssh_key=self.vm_image.ssh_key,
         )
 

--- a/src/bricoler/util.py
+++ b/src/bricoler/util.py
@@ -145,3 +145,13 @@ def warn(message: str):
 def unused_tcp_addr() -> Tuple[str, int]:
     with socket.create_server(('localhost', 0), family=socket.AF_INET) as s:
         return s.getsockname()
+
+
+def parse_p9(line):
+        ret = []
+        for share in line.split(','):
+            pair = share.split(':')
+            if len(pair) < 2:
+                raise ValueError(f"failed to parse p9 share {share}")
+            ret.append((pair[0], Path(pair[1])))
+        return ret

--- a/src/bricoler/vm.py
+++ b/src/bricoler/vm.py
@@ -223,7 +223,7 @@ class BhyveRun(VMRun):
         if self.nic_driver != VMRun.NetworkDriver.NONE:
             add_device(f"{self.network_driver_name()},slirp,open,hostfwd=tcp:{self.ssh_addr[0]}:{self.ssh_addr[1]}-:22")
         for share in self.p9_shares:
-            add_device(f"virtio-9p,{share[0]}={share[1]}")
+            add_device(f"virtio-9p,{share[0]}={str(share[1])}")
 
         bhyve_cmd.extend([vmname])
 


### PR DESCRIPTION
This makes bricoler fail quickly if the user supplies an invalid p9 share.