### PR TITLE
freebsd-regression-test-suite: use pydoc pager to report

### DIFF
--- a/src/bricoler/bricoler.py
+++ b/src/bricoler/bricoler.py
@@ -8,6 +8,7 @@ import functools
 import glob
 import json
 import os
+import pydoc
 import re
 import shutil
 import sqlite3
@@ -1073,7 +1074,8 @@ class FreeBSDRegressionTestSuiteTask(FreeBSDVMBootTask):
         }
 
     def _report(self, *args):
-        self.run_cmd(["less", Path.cwd() / "kyua-report.txt"])
+        with open(Path.cwd() / "kyua-report.txt", 'r') as f:
+            return pydoc.pager(f.read())
 
     actions = {
         'report': _report,


### PR DESCRIPTION
This fixes a broken pipe error when trying to pipe the output of a bricoler report command:

Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe